### PR TITLE
using errors.Is(err, errType) to compare errors instead of ==

### DIFF
--- a/aof.go
+++ b/aof.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"io"
 	"os"
 	"sync"
@@ -71,7 +72,7 @@ func (aof *Aof) Read(fn func(value Value)) error {
 	for {
 		value, err := reader.Read()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 


### PR DESCRIPTION
using errors.Is(err, errType) to compare errors instead of ==. This is the preferred way of comparing errors in Go.
Ex errors.Is(err, io.EOF) {...}